### PR TITLE
Don't parse the web page if there is no results

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -8,6 +8,7 @@ import (
 
 // XPATH
 var (
+	xpathNoResult       = xmlpath.MustCompile("//text()[contains(.,'did not match any documents')]")
 	xpathTorrentResults = xmlpath.MustCompile("//tr[contains(@id, 'torrent_')]")
 	xpathTorrentName    = xmlpath.MustCompile(".//a[@class=\"cellMainLink\"]")
 	xpathTorrentURL     = xmlpath.MustCompile(".//a[contains(@title,'Download torrent file')]/@href")
@@ -26,6 +27,12 @@ var parseFunc = parseResult
 
 func parseResult(root *xmlpath.Node) ([]*Torrent, error) {
 	torrents := []*Torrent{}
+
+	// Don't go further if there is no results
+	if xpathNoResult.Exists(root) {
+		return torrents, nil
+	}
+
 	iter := xpathTorrentResults.Iter(root)
 	for iter.Next() {
 		name, ok := xpathTorrentName.String(iter.Node())


### PR DESCRIPTION
If there is no result, the string "did not match any documents" is displayed and there is a list of pseudo matching torrents underneath it.

I'm not very good with xpath, is there a better way ?
